### PR TITLE
🔧 Bind the window close event only when framed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,10 +116,12 @@ function setWindowAutoHide() {
       ipcMain.emit("tray-window-hidden", { window: window, tray: tray });
     }
   });
-  window.on("close", function(event) {
-    event.preventDefault();
-    window.hide();
-  });
+  if (framed) {
+    window.on("close", function(event) {
+      event.preventDefault();
+      window.hide();
+    });
+  }
 }
 
 function toggleWindow() {


### PR DESCRIPTION
In the current working of the code, the binding to the `close` window event will stop the `app.quit()` (see issue #4) from running completely due to the `event.preventDefault();` line.

As the `close` event is only really beneficial if the window is framed, then I feel that wrapping it with the check for whether the `option.framed` is true before the binding is a better way.

If someone is passing in the window they can apply the binding outside of the scope of the package, but for windows created by the package, the option for framed will dictate the processing of the close event.